### PR TITLE
refactor(files): filesystem changes

### DIFF
--- a/bin/sentinel.js
+++ b/bin/sentinel.js
@@ -11,9 +11,11 @@ program
 program
   .command('init')
   .description('Initializes the templates from core framework repo')
-  .action(() => {
-    console.log(CLI.genAscii());
-    CLI.init();
+  .action(async () => {
+    const ascii = await CLI.genAscii();
+    console.log(ascii);
+    await CLI.init();
+    console.log('Initialization Completed!');
   })
   .on('--help', () => {
     console.log('\n  Examples:');

--- a/lib/cli.js
+++ b/lib/cli.js
@@ -1,20 +1,20 @@
-const path = require('path');
 const DockerCompose = require('./docker-compose');
 const Integration = require('./integration');
-const Npm = require('./npm');
 const figlet = require('figlet');
+const { promisify } = require('./promisify');
 
 class CLI {
   static init() {
-    const root = path.join(__dirname, '..', 'integration');
-    const npm = new Npm();
-    npm.intializeRecursive(root);
+    const int = new Integration();
+    return int.intialize(Integration.integrationDirectory());
   }
 
-  static runCompose(composeCommand, composeArgs, userServices) {
+  static async runCompose(composeCommand, composeArgs, userServices) {
+    const int = new Integration();
     const additionalServices = Array.isArray(userServices) ? userServices : [];
-    const files = Integration.getFiles();
-    const composeFiles = Integration.findCompose(files)
+    const files = await int.getFiles();
+    const composeFiles = Integration
+      .findCompose(files)
       .concat(additionalServices);
 
     if (composeCommand === undefined) {
@@ -24,19 +24,20 @@ class CLI {
     return dc[composeCommand](...composeArgs);
   }
 
-  static runCucumber(cucumberArgs, userServices) {
+  static async runCucumber(cucumberArgs, userServices) {
+    const int = new Integration();
     const additionalServices = Array.isArray(userServices) ? userServices : [];
     const featureDir = process.env.FEATURE_DIR || './features/';
 
     // 1. require support files for each module)
-    let files = Integration.getFiles({ withRelativePaths: true });
+    let files = await int.getFiles({ withRelativePaths: true });
     cucumberArgs.push(...Integration.findSupportJs(files)
       .reduce((a, f) => a.concat('--require', f), [])
       .concat('--require', featureDir)
       .concat('-t', '~@Template'));
 
     // 2. Bootstrap modules
-    files = Integration.getFiles();
+    files = await int.getFiles();
     Integration.findIntegration(files)
       .map(f => require(f)) // eslint-disable-line global-require, import/no-dynamic-require
       .filter(m => m.cucumberArgs)
@@ -52,18 +53,20 @@ class CLI {
       .then(() => dc.run('node', './node_modules/.bin/cucumber.js', ...cucumberArgs));
   }
 
-  static startServices(userServices) {
+  static async startServices(userServices) {
+    const int = new Integration();
     const additionalServices = Array.isArray(userServices) ? userServices : [];
-    const files = Integration.getFiles();
+    const files = await int.getFiles();
     const composeFiles = Integration.findCompose(files)
       .concat(additionalServices);
     const dc = new DockerCompose(composeFiles, [], Integration.integrationDirectory());
     return dc.up('--build', '-d');
   }
 
-  static stopServices(userServices) {
+  static async stopServices(userServices) {
+    const int = new Integration();
     const additionalServices = Array.isArray(userServices) ? userServices : [];
-    const files = Integration.getFiles();
+    const files = await int.getFiles();
     const composeFiles = Integration.findCompose(files)
       .concat(additionalServices);
     const dc = new DockerCompose(composeFiles, [], Integration.integrationDirectory());
@@ -71,16 +74,11 @@ class CLI {
   }
 
   static genAscii() {
-    figlet.text('sentinel', {
+    return promisify(cb => figlet.text('sentinel', {
       font: 'Colossal',
       horizontalLayout: 'fitted',
       verticalLayout: 'default',
-    }, (err, data) => {
-      if (err) {
-        return (err);
-      }
-      return data;
-    });
+    }, cb));
   }
 }
 

--- a/lib/filesystem.js
+++ b/lib/filesystem.js
@@ -1,23 +1,92 @@
 const path = require('path');
 const fs = require('fs');
+const { promisifyObject } = require('./promisify');
 
 class Files {
-  static getDirectories(directory, filter) {
-    const customFilter = typeof filter === 'function' ? filter : () => true;
-    return fs.readdirSync(directory)
-      .filter(subDirectory => fs.statSync(path.join(directory, subDirectory)).isDirectory())
-      .filter(subDirectory => subDirectory[0] !== '.')
-      .filter(customFilter)
-      .map(subDirectory => path.join(directory, subDirectory));
+  constructor() {
+    // Create async version of the fs module
+    this.fsa = promisifyObject(fs, ['readdir', 'stat', 'exists', 'readFile', 'appendFile', 'writeFile']);
   }
 
-  static getDirectoriesRecursive(srcpath, filter) {
-    return [
-      srcpath,
-      ...Files.flatten(Files
-        .getDirectories(srcpath, filter)
-        .map(d => Files.getDirectoriesRecursive(d, filter))),
-    ];
+  async statDirectory(directory, options) {
+    const nameFilter = options && typeof options.nameFilter === 'function' ? options.nameFilter : () => true;
+    const pathFilter = options && typeof options.pathFilter === 'function' ? options.pathFilter : () => true;
+    const data = await this.fsa.readdir(directory);
+    const filtered = data
+      .filter(nameFilter)
+      .map(sd => path.join(directory, sd))
+      .filter(pathFilter);
+    return Promise.all(filtered.map(sd => this.fsa.stat(sd).then(stat => ({
+      path: sd,
+      stat,
+    }))));
+  }
+
+  async statDirectoryRecursive(directory, options) {
+    const stats = await this.statDirectory(directory, options);
+    const dirs = stats.filter(s => s.stat.isDirectory()).map(s => s.path);
+    const substats = await Promise.all(dirs.reduce((agg, dir) =>
+      agg.concat(this.statDirectoryRecursive(dir, options)), []));
+    return Files.flatten(stats.concat(substats));
+  }
+
+  async getDirectories(directory, options) {
+    const stats = await this.statDirectory(directory, options);
+    return stats
+      .filter(s => s.stat.isDirectory())
+      .map(s => s.path);
+  }
+
+  async getFiles(directory, options) {
+    const stats = await this.statDirectory(directory, options);
+    return stats
+      .filter(s => s.stat.isFile())
+      .map(s => s.path);
+  }
+
+  async getDirectoriesRecursive(directory, options) {
+    const dirs = await this.getDirectories(directory, options);
+    const subdirs = await Promise.all(dirs.reduce((agg, dir) =>
+      agg.concat(this.getDirectoriesRecursive(dir, options)), []));
+    return Files.flatten(dirs.concat(subdirs));
+  }
+
+  async getFilesRecursive(directory, options) {
+    const stats = await this.statDirectoryRecursive(directory, options);
+    return stats.filter(s => s.stat.isFile()).map(s => s.path);
+  }
+
+  async exists(filePath) {
+    return this.fsa.exists(filePath).catch(result => result);
+  }
+
+  async copyFile(src, dest) {
+    let target = dest;
+    try {
+      // if dest is an existing dir, copy into it with same filename
+      const destStat = await this.fsa.stat(dest);
+      target = destStat.isDirectory() ? path.join(dest, path.basename(src)) : dest;
+    } catch (e) {
+      // if dest doesnt exist. Ignore and attempt copy
+      if (e.code !== 'ENOENT') {
+        throw e;
+      }
+    }
+    return new Promise((resolve, reject) => {
+      let called = false;
+      const rejectOnce = (e) => {
+        if (!called) {
+          called = true;
+          reject(e);
+        }
+      };
+      const rd = fs.createReadStream(src);
+      rd.on('error', rejectOnce);
+      const wr = fs.createWriteStream(target);
+      wr.on('error', rejectOnce);
+      wr.on('close', resolve);
+      rd.pipe(wr);
+    });
   }
 
   static flatten(lists) {

--- a/lib/integration.js
+++ b/lib/integration.js
@@ -1,19 +1,29 @@
 const path = require('path');
-const shell = require('shelljs');
+const Files = require('./filesystem');
 
 class Integration {
+  constructor() {
+    this.userDirectory = process.cwd();
+    this.featureDir = process.env.FEATURE_DIR || path.join(this.userDirectory, 'features');
+    this.envConsolidate = '# These are the environment variables used in the tests container';
+    this.fs = new Files();
+  }
+
   static packageDirectory() {
     return path.resolve(path.join(__dirname, '..'));
   }
+
   static integrationDirectory() {
     return path.join(Integration.packageDirectory(), 'integration');
   }
-  static getFiles(options) {
+
+  async getFiles(options) {
     const integrationDirectory = Integration.integrationDirectory();
-    const integration = shell.find(integrationDirectory);
-    if (integration.code !== 0) {
+    const exists = await this.fs.exists(integrationDirectory);
+    if (!exists) {
       return [];
     }
+    const integration = await this.fs.getFilesRecursive(integrationDirectory);
     if (options && options.withRelativePaths === true) {
       // Windows returns \ as directory separator. shell.find returns /.
       const cwd = process.cwd().replace(/\\/g, '/');
@@ -25,17 +35,46 @@ class Integration {
     }
     return integration;
   }
+
   static findFeatures(files) {
     return files.filter(f => f.match(/\.feature$/));
   }
+
   static findSupportJs(files) {
     return files.filter(f => f.match(/\/cucumber\/.*\.js$/));
   }
+
   static findCompose(files) {
     return files.filter(f => f.match(/docker-compose\.yml$/));
   }
+
   static findIntegration(files) {
     return files.filter(f => f.match(/integration\.js$/));
+  }
+
+  async intialize(moduleDirectory) {
+    const subDirectoryList = await this.fs
+      .getDirectoriesRecursive(moduleDirectory, { nameFilter: n => n !== 'node_modules' && !n.startsWith('.') });
+    const templateFiles = await Promise.all(subDirectoryList
+      .map(d => this.fs.getFiles(d, { nameFilter: f => f.includes('.template.') })));
+    await Promise.all(templateFiles
+      .filter(l => l)
+      .reduce((agg, cur) => agg.concat(cur), [])
+      .map(async (file) => {
+        if (file.includes('.template.env')) {
+          const input = await this.fs.fsa.readFile(file, { encoding: 'utf8' });
+          this.envConsolidate += `\n${input}`;
+        } else if (file.includes('.template.feature')) {
+          await this.fs.copyFile(file, this.featureDir);
+        } else if (file.includes('.template.json')) {
+          await this.fs.copyFile(file, this.userDirectory);
+        }
+      }));
+    await this.writeConfigFile(path.join(this.userDirectory, 'config.env'), this.envConsolidate);
+  }
+
+  async writeConfigFile(file, contents) {
+    return this.fs.fsa.appendFile(file, contents, { flag: 'w+' });
   }
 }
 

--- a/lib/npm.js
+++ b/lib/npm.js
@@ -1,37 +1,23 @@
 /* eslint-disable no-underscore-dangle, no-console */
 
 const path = require('path');
-const fs = require('fs');
 const { execSync } = require('child_process');
-const { getDirectoriesRecursive, getDirectories } = require('./filesystem');
-const shell = require('shelljs');
+const Files = require('./filesystem');
 
 class Npm {
   constructor() {
-    // We should add a command line arg or Env var to set this
-    this.userDirectory = process.cwd();
-    this.featureDir = process.env.FEATURE_DIR || path.join(this.userDirectory, 'features');
-    this.envConsolidate = '# These are the environment variables used in the tests container';
+    this.fs = new Files();
+    this.filterOptions = { nameFilter: n => n !== 'node_modules' && !n.startsWith('.') };
   }
 
-  intializeRecursive(directory) {
-    const subDirectoryList = getDirectoriesRecursive(directory, d => d !== 'node_modules');
-    subDirectoryList.forEach((where) => {
-      fs.readdirSync(where)
-        .filter(f => f.includes('.template.'))
-        .forEach((file) => {
-          const filePath = path.join(where, file);
-          this._doIntialize(filePath.toString());
-        });
-    });
-    Npm._writeConfigFile(path.join(this.userDirectory, 'config.env'), this.envConsolidate);
-    console.log('Initialization Completed!');
-  }
-
-  static installForSubdirectories(directory) {
-    const subDirectoryList = getDirectories(directory, d => d !== 'node_modules');
-    subDirectoryList
-      .filter(d => fs.existsSync(path.join(d, 'package.json')))
+  async installForSubdirectories(directory) {
+    const subDirectoryList = await this.fs.getDirectories(directory, this.filterOptions);
+    const packageDirs = await Promise.all(subDirectoryList
+      .map(d => this.fs.exists(path.join(d, 'package.json'))
+        .then(exists => ({ dir: d, isNodePackage: exists }))));
+    packageDirs
+      .filter(d => d.isNodePackage)
+      .map(d => d.dir)
       .forEach((dir) => {
         if (dir !== directory) {
           console.log(`Performing "npm install" inside ./${path.relative(directory, dir)}`);
@@ -44,10 +30,14 @@ class Npm {
     execSync(`cd ${where} && npm install`, { env: process.env, stdio: 'inherit' });
   }
 
-  static uninstallForSubdirectories(directory) {
-    const subDirectoryList = getDirectories(directory, d => d !== 'node_modules');
-    subDirectoryList
-      .filter(d => fs.existsSync(path.join(d, 'package.json')))
+  async uninstallForSubdirectories(directory) {
+    const subDirectoryList = await this.fs.getDirectories(directory, this.filterOptions);
+    const packageDirs = await Promise.all(subDirectoryList
+      .map(d => path.join(d, 'package.json'))
+      .map(d => this.fs.exists(d).then(exists => ({ dir: d, isNodePackage: exists }))));
+    packageDirs
+      .filter(d => d.isNodePackage)
+      .map(d => d.dir)
       .forEach((dir) => {
         if (dir !== directory) {
           console.log(`Performing "npm uninstall" inside ./${path.relative(directory, dir)}`);
@@ -58,24 +48,6 @@ class Npm {
 
   static uninstall(dir) {
     execSync(`cd ${dir}  && rm -rf node_modules`, { env: process.env, stdio: 'inherit' });
-  }
-
-  _doIntialize(filePath) {
-    const silentState = shell.config.silent;
-    shell.config.silent = true;
-    if (filePath.includes('.template.env')) {
-      const input = fs.readFileSync(filePath, { encoding: 'utf8' });
-      this.envConsolidate += `\n${input}`;
-    } else if (filePath.includes('.template.feature')) {
-      shell.cp(filePath, this.featureDir);
-    } else if (filePath.includes('.template.json')) {
-      shell.cp(filePath, this.userDirectory);
-    }
-    shell.config.silent = silentState;
-  }
-
-  static _writeConfigFile(file, contents) {
-    fs.appendFileSync(file, contents, { flag: 'w+' });
   }
 }
 

--- a/lib/promisify.js
+++ b/lib/promisify.js
@@ -1,0 +1,20 @@
+class Promisify {
+  static promisifyObject(obj, properties) {
+    const props = properties || Object.keys(obj);
+    return props.reduce((newObj, p) => {
+      // eslint-disable-next-line no-param-reassign
+      newObj[p] = typeof obj[p] === 'function' ? (...args) => Promisify.promisify(cb => obj[p](...args, cb)) : obj[p];
+      return newObj;
+    }, {});
+  }
+  static promisify(func) {
+    return new Promise((r, e) => {
+      func((err, data) => {
+        if (err) e(err);
+        r(data);
+      });
+    });
+  }
+}
+
+module.exports = Promisify;

--- a/lib/run-install.js
+++ b/lib/run-install.js
@@ -1,5 +1,5 @@
-const path = require('path');
 const Npm = require('./npm');
+const Integration = require('./integration');
 
-const root = path.join(__dirname, '..', 'integration');
-Npm.installForSubdirectories(root);
+const npm = new Npm();
+npm.installForSubdirectories(Integration.integrationDirectory());

--- a/lib/run-uninstall.js
+++ b/lib/run-uninstall.js
@@ -1,5 +1,5 @@
-const path = require('path');
 const Npm = require('./npm');
+const Integration = require('./integration');
 
-const root = path.join(__dirname, '..', 'integration');
-Npm.uninstallForSubdirectories(root);
+const npm = new Npm();
+npm.uninstallForSubdirectories(Integration.integrationDirectory());

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sentinel-ast",
-  "version": "1.0.7",
+  "version": "1.0.8",
   "description": "Sentinel automated security testing framework",
   "main": "index.js",
   "repository": "https://github.com/nintexplatform/sentinel",
@@ -40,8 +40,7 @@
     "dotenv": "^2.0.0",
     "figlet": "^1.2.0",
     "js-yaml": "^3.9.1",
-    "lodash.merge": "^4.6.0",
-    "shelljs": "^0.7.8"
+    "lodash.merge": "^4.6.0"
   },
   "devDependencies": {
     "eslint": "^4.6.1",


### PR DESCRIPTION
Removes the shell package which was only added to get a working POC faster.
Changes filesystem methods to be async.
Moves Npm.initialise to integration.initialise