### PR TITLE
fix(run-time-errors):  Reset the cucumber report on each test run and allow global install

### DIFF
--- a/integration/cucumber-report/cucumber/report.js
+++ b/integration/cucumber-report/cucumber/report.js
@@ -11,17 +11,15 @@ const shell = require('shelljs');
 const reporter = require('cucumber-html-reporter');
 
 const reportDirectory = process.env.CUCUMBER_REPORT_DIR || './report/';
-const cucumberRawJsonFile = 'cucumber_report.json';
 
 function bootstrap() {
   shell.mkdir('-p', reportDirectory);
-  shell.rm('-f', path.join(reportDirectory, cucumberRawJsonFile));
 }
 
 function writeReport() {
   try {
-    const jsonFile = path.join(reportDirectory, cucumberRawJsonFile);
     const logTimeStamp = new Date().toISOString();
+    const jsonFile = path.join(reportDirectory, `cucumber_report_${logTimeStamp}.json`);
     const output = path.join(reportDirectory, `cucumber_report_${logTimeStamp}.html`);
     const stat = fs.statSync(jsonFile);
     if (stat.isFile()) {

--- a/integration/cucumber-report/cucumber/report.js
+++ b/integration/cucumber-report/cucumber/report.js
@@ -11,15 +11,18 @@ const shell = require('shelljs');
 const reporter = require('cucumber-html-reporter');
 
 const reportDirectory = process.env.CUCUMBER_REPORT_DIR || './report/';
+const cucumberRawJsonFile = 'cucumber_report.json';
 
 function bootstrap() {
   shell.mkdir('-p', reportDirectory);
+  shell.rm('-f', path.join(reportDirectory, cucumberRawJsonFile));
 }
 
 function writeReport() {
   try {
-    const jsonFile = path.join(reportDirectory, 'cucumber_report.json');
-    const output = path.join(reportDirectory, 'cucumber_report.html');
+    const jsonFile = path.join(reportDirectory, cucumberRawJsonFile);
+    const logTimeStamp = new Date().toISOString();
+    const output = path.join(reportDirectory, `cucumber_report_${logTimeStamp}.html`);
     const stat = fs.statSync(jsonFile);
     if (stat.isFile()) {
       console.log(`Writing a report to ${output}`);

--- a/lib/npm.js
+++ b/lib/npm.js
@@ -27,7 +27,7 @@ class Npm {
   }
 
   static install(where) {
-    execSync(`cd ${where} && npm install`, { env: process.env, stdio: 'inherit' });
+    execSync(`cd ${where} && sudo npm install`, { env: process.env, stdio: 'inherit' });
   }
 
   async uninstallForSubdirectories(directory) {


### PR DESCRIPTION
This PR fixes following issues,
(i) Cucumber html report for OpenZap doesn't "reset" for each test run  #10 
Creates execution files -  html report and raw cucumber json files for each test run. This would avoid override of any pre-existing test results, 

(ii) Resolves global install on sentinel-ast #9 
Passes sudo access to underlying npm install commands for each integration folders. 