### PR TITLE
chore(zap): Optimize base image for Open Zap

### DIFF
--- a/integration/sonar-cube/docker-compose.yml
+++ b/integration/sonar-cube/docker-compose.yml
@@ -1,4 +1,0 @@
-version: "1"
-services:
-  sonarqube:
-    image: sonarqube

--- a/integration/sonar-cube/docker-compose.yml
+++ b/integration/sonar-cube/docker-compose.yml
@@ -1,0 +1,4 @@
+version: "1"
+services:
+  sonarqube:
+    image: sonarqube

--- a/integration/zap/docker-compose.yml
+++ b/integration/zap/docker-compose.yml
@@ -3,6 +3,6 @@ services:
   zap:
     command: [ zap.sh, -daemon, -host, "0.0.0.0", -port, "8080", -config, api.disablekey=true, -config, api.addrs.addr.name=.*, -config, api.addrs.addr.regex=true ]
     env_file: ##WORKING_DIR##/config.env
-    image: owasp/zap2docker-stable
+    image: owasp/zap2docker-bare
     ports:
      - 8080


### PR DESCRIPTION
Use image that has stable version of OpenZap and contains only the necessary required dependencies to run ZAP.