### PR TITLE
Whitelist integrations

### DIFF
--- a/bin/sentinel.js
+++ b/bin/sentinel.js
@@ -5,6 +5,8 @@ const program = require('commander');
 const pkg = require('./../package.json');
 const CLI = require('../lib/cli');
 
+const cli = new CLI();
+
 program
   .version(pkg.version);
 
@@ -14,7 +16,7 @@ program
   .action(async () => {
     const ascii = await CLI.genAscii();
     console.log(ascii);
-    await CLI.init();
+    await cli.init();
     console.log('Initialization Completed!');
   })
   .on('--help', () => {
@@ -27,9 +29,11 @@ program
 program
   .command('run-compose <COMMAND> [ARGS...]')
   .description('Runs docker compose commands')
-  .option('-y, --yaml [FILE]', 'Additional services to start', (f, files) => files.concat(f), [])
-  .action((cmd, args, options) => CLI.runCompose(cmd, args, options.yaml)
-    .catch(() => process.exit(1)))
+  .action((cmd, args) => cli.runCompose(cmd, args)
+    .catch((ex) => {
+      console.log(ex);
+      process.exit(1);
+    }))
   .on('--help', () => {
     console.log('\n  Examples:');
     console.log();
@@ -42,7 +46,6 @@ const gatherCucumberArgs = param => val => cucumberArgs.concat(param, val);
 program
   .command('run-cucumber [<DIR>|<FILE[:LINE]>...]')
   .description('Executes cucumber tests')
-  .option('-y, --yaml [FILE]', 'Additional services to start', (f, files) => files.concat(f), [])
   .option('-n, --name', 'To specify a scenario by its name matching a regular expression', gatherCucumberArgs('--name'))
   .option('-r, --require <FILE|DIR>', 'To require support files before executing the features', gatherCucumberArgs('--require'))
   .option('-f, --format <TYPE[:PATH]>', 'To specify the format of the output', gatherCucumberArgs('--format'))
@@ -51,8 +54,11 @@ program
   .option('-t, --tag <EXPRESSION>', 'To run specific features or scenarios', gatherCucumberArgs('--tag'))
   .option('-c, --compiler <file_extension>:<module_name>', 'To transpile Step definitions and support files written in other languages to JS', gatherCucumberArgs('--compiler'))
   .option('-w, --world-parameters <JSON>', 'To pass in parameters to pass to the world constructor', gatherCucumberArgs('--world-parameters'))
-  .action((args, options) => CLI.runCucumber(cucumberArgs.concat(args), options.yaml)
-    .catch(() => process.exit(1)))
+  .action(args => cli.runCucumber(cucumberArgs.concat(args))
+    .catch((ex) => {
+      console.log(ex);
+      process.exit(1);
+    }))
   .on('--help', () => {
     console.log('\n  Examples:');
     console.log();
@@ -63,26 +69,30 @@ program
 program
   .command('start-services')
   .description('Starts all the needed docker containers')
-  .option('-y, --yaml [FILE]', 'Additional services to start', (f, files) => files.concat(f), [])
-  .action(cmd => CLI.startServices(cmd.yaml)
-    .catch(() => process.exit(1)))
+  .action(() => cli.startServices()
+    .catch((ex) => {
+      console.log(ex);
+      process.exit(1);
+    }))
   .on('--help', () => {
     console.log('\n  Examples:');
     console.log();
-    console.log('    $ sentinel start-services -y ./path/to/docker-compose.yml');
+    console.log('    $ sentinel start-services');
     console.log();
   });
 
 program
   .command('stop-services')
   .description('Stops all the needed docker containers')
-  .option('-y, --yaml [FILE]', 'Additional services to start', (f, files) => files.concat(f), [])
-  .action(cmd => CLI.stopServices(cmd.yaml)
-    .catch(() => process.exit(1)))
+  .action(() => cli.stopServices()
+    .catch((ex) => {
+      console.log(ex);
+      process.exit(1);
+    }))
   .on('--help', () => {
     console.log('\n  Examples:');
     console.log();
-    console.log('    $ sentinel stop-services -y ./path/to/docker-compose.yml');
+    console.log('    $ sentinel stop-services');
     console.log();
   });
 

--- a/integration/docker/cucumber/docker.steps.js
+++ b/integration/docker/cucumber/docker.steps.js
@@ -32,13 +32,13 @@ module.exports = function () {
         dockerImage += `:${dockerTag}`;
       }
       if (p.type === 'file') {
-        return this.docker.cmd('run', '-v', '$(pwd):/wd', dockerImage, 'cp', p.fromPath, `/wd/${p.toPath}`)
+        return this.docker.cmd('run', '--rm', '-v', '$(pwd):/wd', dockerImage, 'cp', p.fromPath, `/wd/${p.toPath}`)
           .then(({ result, code }) => {
             assert(code === 0, 'Copy was unsuccessful');
             return result;
           });
       }
-      return this.docker.cmd('run', '-v', '$(pwd):/wd', dockerImage, 'cp', '-R', p.fromPath, `/wd/${p.toPath}`)
+      return this.docker.cmd('run', '--rm', '-v', '$(pwd):/wd', dockerImage, 'cp', '-R', p.fromPath, `/wd/${p.toPath}`)
         .then(({ result, code }) => {
           assert(code === 0, 'Copy was unsuccessful');
           return result;

--- a/lib/cli.js
+++ b/lib/cli.js
@@ -1,21 +1,39 @@
+const figlet = require('figlet');
+const Config = require('./configrc');
 const DockerCompose = require('./docker-compose');
 const Integration = require('./integration');
-const figlet = require('figlet');
 const { promisify } = require('./promisify');
 
 class CLI {
-  static init() {
-    const int = new Integration();
-    return int.intialize(Integration.integrationDirectory());
+  constructor() {
+    this.int = new Integration();
+    this.configrc = new Config();
+    this.whitelistedIntegrations = [];
+    this.additionalServices = [];
+    this.readConfig = async () => {
+      this.config = await this.configrc.readFile();
+      this.additionalServices = this.config
+        && this.config.integrations
+        && Array.isArray(this.config.integrations.customServices)
+        ? this.config.integrations.customServices : [];
+      this.whitelistedIntegrations = this.config
+        && this.config.integrations
+        && Array.isArray(this.config.integrations.whitelist)
+        ? this.config.integrations.whitelist : [];
+    };
   }
 
-  static async runCompose(composeCommand, composeArgs, userServices) {
-    const int = new Integration();
-    const additionalServices = Array.isArray(userServices) ? userServices : [];
-    const files = await int.getFiles();
+  async init() {
+    await this.int.intialize(Integration.integrationDirectory());
+    await this.configrc.ensureFile();
+  }
+
+  async runCompose(composeCommand, composeArgs) {
+    await this.readConfig();
+    const files = await this.int.getFiles();
     const composeFiles = Integration
       .findCompose(files)
-      .concat(additionalServices);
+      .concat(this.additionalServices);
 
     if (composeCommand === undefined) {
       throw new Error('docker-compose command required. e.g. run-compose ps');
@@ -24,20 +42,24 @@ class CLI {
     return dc[composeCommand](...composeArgs);
   }
 
-  static async runCucumber(cucumberArgs, userServices) {
-    const int = new Integration();
-    const additionalServices = Array.isArray(userServices) ? userServices : [];
+  async runCucumber(cucumberArgs) {
+    await this.readConfig();
     const featureDir = process.env.FEATURE_DIR || './features/';
 
     // 1. require support files for each module)
-    let files = await int.getFiles({ withRelativePaths: true });
+    let files = await this.int.getFiles({
+      withRelativePaths: true,
+      whitelistedIntegrations: this.whitelistedIntegrations,
+    });
     cucumberArgs.push(...Integration.findSupportJs(files)
       .reduce((a, f) => a.concat('--require', f), [])
       .concat('--require', featureDir)
       .concat('-t', '~@Template'));
 
     // 2. Bootstrap modules
-    files = await int.getFiles();
+    files = await this.int.getFiles({
+      whitelistedIntegrations: this.whitelistedIntegrations,
+    });
     Integration.findIntegration(files)
       .map(f => require(f)) // eslint-disable-line global-require, import/no-dynamic-require
       .filter(m => m.cucumberArgs)
@@ -46,29 +68,31 @@ class CLI {
       });
 
     const composeFiles = Integration.findCompose(files)
-      .concat(additionalServices);
+      .concat(this.additionalServices);
     const dc = new DockerCompose(composeFiles, [], Integration.integrationDirectory());
     return Promise.resolve()
       .then(() => dc.up('--build', '-d'))
       .then(() => dc.run('node', './node_modules/.bin/cucumber.js', ...cucumberArgs));
   }
 
-  static async startServices(userServices) {
-    const int = new Integration();
-    const additionalServices = Array.isArray(userServices) ? userServices : [];
-    const files = await int.getFiles();
+  async startServices() {
+    await this.readConfig();
+    const files = await this.int.getFiles({
+      whitelistedIntegrations: this.whitelistedIntegrations,
+    });
     const composeFiles = Integration.findCompose(files)
-      .concat(additionalServices);
+      .concat(this.additionalServices);
     const dc = new DockerCompose(composeFiles, [], Integration.integrationDirectory());
     return dc.up('--build', '-d');
   }
 
-  static async stopServices(userServices) {
-    const int = new Integration();
-    const additionalServices = Array.isArray(userServices) ? userServices : [];
-    const files = await int.getFiles();
+  async stopServices() {
+    await this.readConfig();
+    const files = await this.int.getFiles({
+      whitelistedIntegrations: this.whitelistedIntegrations,
+    });
     const composeFiles = Integration.findCompose(files)
-      .concat(additionalServices);
+      .concat(this.additionalServices);
     const dc = new DockerCompose(composeFiles, [], Integration.integrationDirectory());
     return dc.down();
   }

--- a/lib/configrc.js
+++ b/lib/configrc.js
@@ -1,0 +1,42 @@
+const Files = require('./filesystem');
+
+class Config {
+  constructor(filename = '.sentinel.json') {
+    this.filename = filename;
+    this.default = {
+      integrations: {
+        whitelist: [],
+        customServices: [],
+      },
+    };
+  }
+  async ensureFile() {
+    const fs = new Files();
+    try {
+      await fs.fsa.writeFile(
+        this.filename,
+        JSON.stringify(this.default, null, 2),
+        { flag: 'wx' },
+      );
+    } catch (ex) {
+      // Ignore the file if it already exists.
+      if (ex.code !== 'EEXIST') {
+        throw ex;
+      }
+    }
+  }
+  async readFile() {
+    const fs = new Files();
+    try {
+      const contents = await fs.fsa.readFile(this.filename);
+      return JSON.parse(contents);
+    } catch (ex) {
+      if (ex.code !== 'ENOTEXISTS') {
+        throw ex;
+      }
+    }
+    return this.default;
+  }
+}
+
+module.exports = Config;

--- a/lib/integration.js
+++ b/lib/integration.js
@@ -23,7 +23,14 @@ class Integration {
     if (!exists) {
       return [];
     }
-    const integration = await this.fs.getFilesRecursive(integrationDirectory);
+    const integrationEnabled = d => !Array.isArray(options.whitelistedIntegrations)
+      || options.whitelistedIntegrations.length === 0
+      || options.whitelistedIntegrations.some(wld => d.endsWith(wld));
+    const integrationDirectories = await this.fs.getDirectories(integrationDirectory, options);
+    const integrationFiles = await Promise.all(integrationDirectories
+      .filter(integrationEnabled)
+      .map(d => this.fs.getFilesRecursive(d, options)));
+    const integration = integrationFiles.reduce((agg, c) => agg.concat(c), []);
     if (options && options.withRelativePaths === true) {
       // Windows returns \ as directory separator. shell.find returns /.
       const cwd = process.cwd().replace(/\\/g, '/');

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sentinel-ast",
-  "version": "1.3.1",
+  "version": "1.4.0",
   "description": "Sentinel automated security testing framework",
   "main": "index.js",
   "repository": "https://github.com/nintexplatform/sentinel",


### PR DESCRIPTION
* Init now creates a .sentinel.json file which contains some project specific config which is used by the cli.
* Allow the user to specify which integrations they are using so that we only start containers that will be used. 
e.g. Snyk package scanning may only require "node", "docker", "snyk.io" integrations
* Removes the BYO container arguments (--yaml) and move that config into the new .sentinel.json file.
This simplifies forwarding arguments to the cucumber/docker-compose cli tools. 
