### PR TITLE
manage new sslyze version

### DIFF
--- a/integration/sslyze/cucumber/sslyze.steps.js
+++ b/integration/sslyze/cucumber/sslyze.steps.js
@@ -37,14 +37,14 @@ module.exports = function () {
   });
 
   this.Then(/^the SSLyze output must contain a line that matches (.*)$/, async function (regex) {
-    assert.equal((this.sslyzeOutput.search(regex) !== -1), `${errorMessage}: SSLyze scan didnot contain any line matching - '${regex}'`);
+    assert(this.sslyzeOutput.search(regex) !== -1, `${errorMessage}: SSLyze scan didnot contain any line matching - '${regex}'`);
   });
 
   this.Then(/^the minimum key size must be (.*) bits$/, function (arg1) {
     assert(this.ciphersSupported.length > 0, `${errorMessage}: The host does not support any valid ciphers`);
 
     this.ciphersSupported.forEach((ciphers) => {
-      assert(ciphers.size >= arg1, `${errorMessage}: ${ciphers.name} has key size less than 128 bits`);
+      assert(ciphers.size >= arg1, `${errorMessage}: ${ciphers.name} has key size less than ${arg1} bits`);
     });
   });
 
@@ -93,7 +93,7 @@ module.exports = function () {
   });
 
   this.Then(/^the certificate has a matching host name$/, function () {
-    assert(this.sslyzeOutput.indexOf(`${env.serverHostName}`) !== -1, `${errorMessage}: None of Certificate has matching hostname - ${env.serverHostName}`);
+    assert(this.sslyzeOutput.indexOf(`${env.serverHostName.replace(/^https?:\/\//,'')}`) !== -1, `${errorMessage}: None of Certificate has matching hostname - ${env.serverHostName.replace(/^https?:\/\//,'')}`);
   });
 
   this.Then(/^the certificate is in major root CA trust stores$/, function () {

--- a/integration/sslyze/features/sslyze-scan.template.feature
+++ b/integration/sslyze/features/sslyze-scan.template.feature
@@ -3,7 +3,7 @@ Feature: SSL
   Ensure that the SSL configuration of the service is robust
 
 Background: Run the SSLyze command only once for all features
-  When the SSLyze command is run against the "<Put your URL here>"
+  When the SSLyze command is run against the host
 
 #SSL- CRIME ATTACK
 Scenario: Disable SSL deflate compression in order to mitigate the risk of the CRIME attack
@@ -11,16 +11,16 @@ Scenario: Disable SSL deflate compression in order to mitigate the risk of the C
 
 #SSL- CLIENT RENEGOTIATION
 Scenario: Disable client renegotiations
-  Then the SSLyze output must contain a line that matches .*Client-initiated Renegotiation?:\s+OK - Rejected.*
+  Then the SSLyze output must contain a line that matches .*Client-initiated Renegotiation:\s+OK - Rejected.*
 
-#SSL - Secure Renegotiations 
+#SSL - Secure Renegotiations
 Scenario: Server should support secure renegotiation
-  Then the SSLyze output must contain a line that matches .*Secure Renegotiation?:\s+OK - Supported.*
+  Then the SSLyze output must contain a line that matches .*Secure Renegotiation:\s+OK - Supported.*
 
 #SSL - HEARTBLEED
 @Manual
 Scenario: Patch OpenSSL against the Heartbleed vulnerability
-  Then the SSLyze output must contain a line that matches .*Not vulnerable to Heartbleed.*
+  Then the SSLyze output must contain the text "OK - Not vulnerable to Heartbleed"
 
 #SSL - Strong Cipher
 Scenario: The minimum cipher strength should meet requirements
@@ -30,9 +30,10 @@ Scenario: The minimum cipher strength should meet requirements
 Scenario: Disable weak SSL protocols due to numerous cryptographic weaknesses
   Then the following protocols must not be supported
       |protocol	  |
-      |SSLV1      |
-      |SSLV2      |
-      |SSLV3      |
+      |SSL 2.0    |
+      |SSL 3.0    |
+      |TLS 1.1    |
+      |TLS 1.0    |
 
 #SSL - OpenSSL CCS Injection vulnerability
 Scenario: Server should not be vulnerable to OpenSSL CCS Injection
@@ -42,11 +43,9 @@ Scenario: Server should not be vulnerable to OpenSSL CCS Injection
 Scenario: Support TLSv1.2
   Then the following protocols must be supported
       |protocol	|
-      |TLSV1_2  |
-      |TLSV1_1  |
-      |TLSV1    |
+      |TLS 1.2  |
 
-#SSL - Perfect Forward Secrecy 
+#SSL - Perfect Forward Secrecy
 Scenario: Enable Perfect forward secrecy
   Then any of the following ciphers must be supported
       | ciphers                               |
@@ -54,32 +53,12 @@ Scenario: Enable Perfect forward secrecy
       |TLS_ECDHE_RSA_WITH_AES_256_CBC_SHA384  |
       |TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256  |
       |TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA256  |
-      |ECDHE-RSA-AES128-SHA                   |
-      |ECDHE-RSA-AES256-SHA                   |
-      |DHE-DSS-CAMELLIA128-SHA                |
-      |DHE-DSS-CAMELLIA256-SHA                |
-      |DHE-RSA-CAMELLIA128-SHA                |
-      |DHE-RSA-CAMELLIA256-SHA                |
-      |ECDHE-ECDSA-CAMELLIA128-SHA256         |
-      |ECDHE-ECDSA-CAMELLIA256-SHA384         |
-      |ECDH-ECDSA-CAMELLIA128-SHA256          |
-      |ECDH-ECDSA-CAMELLIA256-SHA384          |
-      |ECDHE-RSA-CAMELLIA128-SHA256           |
-      |ECDHE-RSA-CAMELLIA256-SHA384           |
-      |ECDH-RSA-CAMELLIA128-SHA256            |
-      |ECDH-RSA-CAMELLIA256-SHA384            |
 
-#SSL - Strict TLS Header
-Scenario: The server should set Strict TLS headers
-  #Then the output must contain a line that matches .*OK - HSTS header received:\s+max-age=31536000; includeSubDomains.*
-  Then the SSLyze output must contain a line that matches .*Max Age:\s+31536000.*
-  Then the SSLyze output must contain a line that matches .*Include Subdomains:\s+True.*
-
-#SSL - Not Support SHA-1 Certificate 
+#SSL - Not Support SHA-1 Certificate
 Scenario: The certificate does not use SHA-1 any more
   Then the SSLyze output must contain a line that matches .*OK - No SHA1-signed certificate in the verified certificate chain.*
 
-#SSL - Weak Cipher Suites 
+#SSL - Weak Cipher Suites
 Scenario: Weak cipher suites should be disabled
   Then the following ciphers must not be supported
          | cipher       |
@@ -96,7 +75,7 @@ Scenario: Weak cipher suites should be disabled
 Scenario: The server key should be large enough
   Then the SSLyze output must contain a line that matches .*Key Size:\s+2048.*
 
-#Certificate Should be in valid 
+#Certificate Should be in valid
 Scenario: The server certificate should be trusted
   Then the certificate has a matching host name
   And the certificate is in major root CA trust stores

--- a/integration/sslyze/pages/sslyze.js
+++ b/integration/sslyze/pages/sslyze.js
@@ -18,7 +18,7 @@ class Sslyze {
         }
 
         // Look for the Accepted Cipher Suites - TurnON flag accordingly
-        if (line.indexOf('Accepted:') !== -1) {
+        if (line.search('The server accepted the following.*cipher suites:') !== -1) {
           readFlag = true;
         }
 
@@ -45,20 +45,20 @@ class Sslyze {
         }
 
         // Identify the Protocols
-        if (line.indexOf('Cipher Suites:') !== -1) {
-          temp = line.split(/\s+/);
+        if (line.indexOf('Cipher suites:') !== -1) {
+          temp = line.match(/(SSL|TLS) \d+\.\d+/g)         
           return;
         }
 
         // Push the Protocols which are Rejected
         if ((line.indexOf('rejected') !== -1) && (temp !== '')) {
-          protocol.push({ name: temp[2], type: 'Rejected' });
+          protocol.push({ name: temp[0], type: 'Rejected' });
           temp = '';
         }
 
         // Push the Protocols which are Supported
         if ((line.indexOf('Preferred') !== -1) && (temp !== '')) {
-          protocol.push({ name: temp[2], type: 'Supported' });
+          protocol.push({ name: temp[0], type: 'Supported' });
           temp = '';
         }
       });

--- a/integration/sslyze/service/Dockerfile
+++ b/integration/sslyze/service/Dockerfile
@@ -2,7 +2,7 @@ FROM python:3.7-slim
 RUN pip install sslyze
 RUN apt-get update
 RUN apt-get -y install gnupg curl
-RUN curl -sL https://deb.nodesource.com/setup_10.x | bash
+RUN curl -sL https://deb.nodesource.com/setup_12.x | bash
 RUN apt-get -y install nodejs
 
 WORKDIR /app

--- a/integration/sslyze/service/Dockerfile
+++ b/integration/sslyze/service/Dockerfile
@@ -1,9 +1,10 @@
 FROM python:3.7-slim
 WORKDIR /app
 ADD ./package.json ./package.json
-RUN pip install sslyze && apt-get update && apt-get -y install --no-install-recommends gnupg curl \
+RUN pip install -U sslyze && apt-get update && apt-get -y install --no-install-recommends gnupg curl \
     && curl -sL https://deb.nodesource.com/setup_12.x | bash \ 
     && apt-get -y install --no-install-recommends nodejs && npm install \
-    && apt-get clean && rm -rf /var/lib/apt/lists/*
+    && npm cache clean --force --loglevel=error && rm -fr ~/.cache/pip \
+    && apt-get clean && rm -rf /var/lib/apt/lists/* && apt-get autoclean
 ADD ./index.js ./index.js
 CMD ["node", "index.js"]

--- a/integration/sslyze/service/Dockerfile
+++ b/integration/sslyze/service/Dockerfile
@@ -1,12 +1,9 @@
 FROM python:3.7-slim
-RUN pip install sslyze
-RUN apt-get update
-RUN apt-get -y install gnupg curl
-RUN curl -sL https://deb.nodesource.com/setup_12.x | bash
-RUN apt-get -y install nodejs
-
 WORKDIR /app
 ADD ./package.json ./package.json
-RUN npm install
+RUN pip install sslyze && apt-get update && apt-get -y install --no-install-recommends gnupg curl \
+    && curl -sL https://deb.nodesource.com/setup_12.x | bash \ 
+    && apt-get -y install --no-install-recommends nodejs && npm install \
+    && apt-get clean && rm -rf /var/lib/apt/lists/*
 ADD ./index.js ./index.js
 CMD ["node", "index.js"]


### PR DESCRIPTION
It seems that new sslyze versions have a different output format
Also the node version used in the Dockerfile was a bit old
About the changes on features/sslyze-scan.template.feature maybe they are not the best, these fits our needs but please review in case you want consider my PR

I also changed something on the dockerfile to save some space, is not so much about 70 MB but was an easy win. More savings seems to be hard consider that nodejs require python 2.7 and sslyze seems to rely to python3.