### PR TITLE
fix function timeout error in zap ascan

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -193,6 +193,8 @@ Extending the framework starts with packaging your new **component** as a sub-di
 |---------------------|-----------------------------|--------------------------------|----------|-------------|
 | sslyze              | SSLYZE_SERVER_URL           | Url to sslyze api server       | false    | http://sslyze:8081/ |
 | zap                 | ZAP_SERVER_URL              | Url to zap api server          | false    | http://zap:8080/    |
+| zap                 | ZAP_MAX_DEPTH               | zap crawling max depth         | false    | 5           |
+| zap                 | ZAP_THREAD_DEPTH            | zap thread number              | false    | 5           | 
 | snyk                | SNYK_TOKEN                  | [Auth token](https://snyk.io/docs/using-snyk#authentication) for snyk| false    |                     |
 | snyk                | SNYK_URL                    | Url to snyk api server         | false    | http://snyk:8086/   |
 | application         | AUT_SERVER_URL              | Url to application under test  | true     | https://nodegoat:4000 |
@@ -203,6 +205,7 @@ Extending the framework starts with packaging your new **component** as a sub-di
 | selenium            | WEBDRIVER_LONG_TIMEOUT      | Timeout for long running step  | false    |  30000      |
 | selenium            | EXECUTION_ENVIRONMENT       | For zap proxy                  | false    |  local (default) / proxy / remote |
 | cucumber            | FEATURE_DIR                 | Feature file location          | false    | ./features/  |
+| cucumber            | CUCUMBER_LONG_TIMEOUT       | timeout for cucumber steps     | false    | 30000        |
 | cucumber-report     | CUCUMBER_REPORT_DIR         | path to store reports          | false    | ./report/    |
 | slack               | SLACK_FEATURE               | *ON* or *OFF* the process      | false    | 'ON' / 'OFF' (default) |    
 | slack               | SLACK_WEBHOOK_URI           | Specify the Incoming webhooks url - [Reference](https://api.slack.com/incoming-webhooks)   |   false |  - |       

--- a/integration/selenium/docker-compose.yml
+++ b/integration/selenium/docker-compose.yml
@@ -1,4 +1,5 @@
-version: "2"
+version: "3.5"
 services:
   selenium:
     image: selenium/standalone-chrome
+    shm_size: '1gb'

--- a/integration/zap/cucumber/environment.js
+++ b/integration/zap/cucumber/environment.js
@@ -3,4 +3,6 @@ const sharedEnv = require('../../../lib/environment');
 module.exports = Object.assign({}, sharedEnv, {
   server: process.env.ZAP_SERVER_URL || 'http://zap:8080/',
   scanTimeout: sharedEnv.parseTimeout(process.env.ZAP_SCAN_TIMEOUT, 30000),
+  maxDepth: process.env.ZAP_MAX_DEPTH || 5,
+  threadCount: process.env.ZAP_THREAD_COUNT || 5,
 });

--- a/integration/zap/cucumber/zap.steps.js
+++ b/integration/zap/cucumber/zap.steps.js
@@ -23,15 +23,15 @@ async function waitForResult(result, timeout, action) {
     if (timeout > 0 && Date.now() > (now + timeout)) {
       throw new Error('Timeout waiting for zap scan to complete');
     }
-    await sleep(500); // eslint-disable-line no-await-in-loop
+    await sleep(1000); // eslint-disable-line no-await-in-loop
     done = await action(); // eslint-disable-line no-await-in-loop
   }
 }
 
 module.exports = function () {
   this.Then(/^the application is spidered/, { timeout: env.longTimeout }, async function () {
-    zap.setsetOptionMaxDepth(5);
-    zap.setOptionThreadCount(5);
+    zap.setsetOptionMaxDepth(env.maxDepth);
+    zap.setOptionThreadCount(env.threadCount);
 
     url = await this.driver.getCurrentUrl();
 
@@ -44,7 +44,7 @@ module.exports = function () {
     await zap.startPassiveScan();
   });
 
-  this.Then(/^the active scanner is run/, async function () {
+  this.Then(/^the active scanner is run/, { timeout: env.longTimeout }, async function () {
     const resp = await zap.startActiveScan(url);
     const scanID = resp.scan;
     await waitForResult(true, env.scanTimeout, () => zap.checkActiveScanStatus(scanID));


### PR DESCRIPTION
When you have a big or a particular website the active scan my take a lot of time so you can receive a timeout error on cucumber. 
I added some configs to solve this problem (long timeout that you introduce but not in the table and not applied to active scan) or to have a better customisation of the test. 
I would keep the software simple as you designed it however maxdepth and thread could let the users to easily customise the behaviour without work with zap api.

you can test zap on www.beefree.io to notice the timeout error. 